### PR TITLE
Fixes for ML Rule tests

### DIFF
--- a/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
+++ b/x-pack/legacy/plugins/siem/cypress/integration/signal_detection_rules_ml.spec.ts
@@ -23,7 +23,8 @@ import {
   ABOUT_RULE_DESCRIPTION,
   RULE_TYPE,
   ANOMALY_SCORE,
-  MACHINE_LEARNING_JOB,
+  MACHINE_LEARNING_JOB_STATUS,
+  MACHINE_LEARNING_JOB_ID,
 } from '../screens/rule_details';
 import {
   CUSTOM_RULES_BTN,
@@ -165,13 +166,17 @@ describe('Signal detection rules, machine learning', () => {
     cy.get(DEFINITION_STEP)
       .eq(RULE_TYPE)
       .invoke('text')
-      .should('eql', 'machine_learning');
+      .should('eql', 'Machine Learning');
     cy.get(DEFINITION_STEP)
       .eq(ANOMALY_SCORE)
       .invoke('text')
       .should('eql', machineLearningRule.anomalyScoreThreshold);
     cy.get(DEFINITION_STEP)
-      .eq(MACHINE_LEARNING_JOB)
+      .get(MACHINE_LEARNING_JOB_STATUS)
+      .invoke('text')
+      .should('eql', 'Stopped');
+    cy.get(DEFINITION_STEP)
+      .get(MACHINE_LEARNING_JOB_ID)
       .invoke('text')
       .should('eql', machineLearningRule.machineLearningJob);
 

--- a/x-pack/legacy/plugins/siem/cypress/screens/rule_details.ts
+++ b/x-pack/legacy/plugins/siem/cypress/screens/rule_details.ts
@@ -32,7 +32,9 @@ export const DEFINITION_INDEX_PATTERNS =
 export const DEFINITION_STEP =
   '[data-test-subj=definitionRule] [data-test-subj="listItemColumnStepRuleDescription"] .euiDescriptionList__description';
 
-export const MACHINE_LEARNING_JOB = 2;
+export const MACHINE_LEARNING_JOB_ID = '[data-test-subj=machineLearningJobId]';
+
+export const MACHINE_LEARNING_JOB_STATUS = '[data-test-subj=machineLearningJobStatus]';
 
 export const RULE_NAME_HEADER = '[data-test-subj="header-page-title"]';
 

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/description_step/ml_job_description.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/description_step/ml_job_description.tsx
@@ -71,7 +71,7 @@ export const MlJobDescription: React.FC<{ job: SiemJob }> = ({ job }) => {
   return (
     <Wrapper>
       <div>
-        <JobLink href={jobUrl} target="_blank">
+        <JobLink data-test-subj="machineLearningJobId" href={jobUrl} target="_blank">
           {job.id}
         </JobLink>
         <AuditIcon message={job.auditMessage} />

--- a/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/description_step/ml_job_description.tsx
+++ b/x-pack/legacy/plugins/siem/public/pages/detection_engine/rules/components/description_step/ml_job_description.tsx
@@ -47,11 +47,13 @@ const AuditIcon: React.FC<{
 
 export const JobStatusBadge: React.FC<{ job: SiemJob }> = ({ job }) => {
   const isStarted = isJobStarted(job.jobState, job.datafeedState);
+  const color = isStarted ? 'secondary' : 'danger';
+  const text = isStarted ? ML_JOB_STARTED : ML_JOB_STOPPED;
 
-  return isStarted ? (
-    <EuiBadge color="secondary">{ML_JOB_STARTED}</EuiBadge>
-  ) : (
-    <EuiBadge color="danger">{ML_JOB_STOPPED}</EuiBadge>
+  return (
+    <EuiBadge data-test-subj="machineLearningJobStatus" color={color}>
+      {text}
+    </EuiBadge>
   );
 };
 


### PR DESCRIPTION
## Summary

This updates the ML Rule Cypress tests following elastic/kibana#61182.

@MadameSheema I added an additional assertion for the new status badge there, which involved adding some new selectors. I opted for chaining independent `[data-test-subj]` selectors rather than defining composite ones; feel free to change it to whatever you see fit.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

